### PR TITLE
Added factory for MeteredSequentiallyAsync

### DIFF
--- a/sequentially-metrics/src/main/scala/com/evolutiongaming/concurrent/MeteredSequentiallyAsync.scala
+++ b/sequentially-metrics/src/main/scala/com/evolutiongaming/concurrent/MeteredSequentiallyAsync.scala
@@ -6,11 +6,19 @@ import scala.concurrent.Future
 
 object MeteredSequentiallyAsync {
 
+  type Factory[K] = String => SequentiallyAsync[K]
+
   def apply[K](sequentially: SequentiallyAsync[K],
                name: String,
                sequentiallyMetrics: SequentiallyMetrics.Factory,
   ): SequentiallyAsync[K] = {
     apply(sequentially, sequentiallyMetrics(name))
+  }
+
+  def apply[K](sequentially: => SequentiallyAsync[K],
+               sequentiallyMetrics: SequentiallyMetrics.Factory,
+  ): Factory[K] = {
+    name => apply(sequentially, sequentiallyMetrics(name))
   }
 
   def apply[K](sequentially: SequentiallyAsync[K],

--- a/sequentially-metrics/src/main/scala/com/evolutiongaming/concurrent/MeteredSequentiallyAsync.scala
+++ b/sequentially-metrics/src/main/scala/com/evolutiongaming/concurrent/MeteredSequentiallyAsync.scala
@@ -6,19 +6,11 @@ import scala.concurrent.Future
 
 object MeteredSequentiallyAsync {
 
-  type Factory[K] = String => SequentiallyAsync[K]
-
   def apply[K](sequentially: SequentiallyAsync[K],
                name: String,
                sequentiallyMetrics: SequentiallyMetrics.Factory,
   ): SequentiallyAsync[K] = {
     apply(sequentially, sequentiallyMetrics(name))
-  }
-
-  def apply[K](sequentially: => SequentiallyAsync[K],
-               sequentiallyMetrics: SequentiallyMetrics.Factory,
-  ): Factory[K] = {
-    name => apply(sequentially, sequentiallyMetrics(name))
   }
 
   def apply[K](sequentially: SequentiallyAsync[K],
@@ -34,6 +26,16 @@ object MeteredSequentiallyAsync {
 
       sequentially.async(key)(run())
     }
+  }
+
+  type Factory[K] = String => SequentiallyAsync[K]
+
+  object Factory {
+
+    def apply[K](sequentially: => SequentiallyAsync[K],
+                 sequentiallyMetrics: SequentiallyMetrics.Factory,
+    ): Factory[K] =
+      name => MeteredSequentiallyAsync(sequentially, sequentiallyMetrics(name))
   }
 
 }


### PR DESCRIPTION
Motivation:

Sometimes there is a need to have the same flexibility as `SequentiallyMetrics.Factory` has: be able to provide MeteredSequentiallyAsync instance from the same `SequentiallyMetrics.Factory` and same `SequentiallyAsync` constructor dynamically by name