### PR TITLE
Improved MeteredSequentiallyAsync Factory

### DIFF
--- a/sequentially-metrics/src/main/scala/com/evolutiongaming/concurrent/MeteredSequentiallyAsync.scala
+++ b/sequentially-metrics/src/main/scala/com/evolutiongaming/concurrent/MeteredSequentiallyAsync.scala
@@ -28,14 +28,22 @@ object MeteredSequentiallyAsync {
     }
   }
 
-  type Factory[K] = String => SequentiallyAsync[K]
+  trait Factory {
+    def apply[K](name: String): SequentiallyAsync[K]
+  }
 
   object Factory {
 
-    def apply[K](sequentially: => SequentiallyAsync[K],
-                 sequentiallyMetrics: SequentiallyMetrics.Factory,
-    ): Factory[K] =
-      name => MeteredSequentiallyAsync(sequentially, sequentiallyMetrics(name))
+    trait Provider {
+      def apply[K]: SequentiallyAsync[K]
+    }
+
+    def apply(provider: Provider,
+              sequentiallyMetrics: SequentiallyMetrics.Factory,
+    ): Factory = new Factory {
+      override def apply[K](name: String): SequentiallyAsync[K] =
+        MeteredSequentiallyAsync(provider.apply[K], sequentiallyMetrics(name))
+    }
   }
 
 }


### PR DESCRIPTION
Fix for my previously introduced functionality 😅 

Motivation:
As practice shown construction of SequentiallyAsync is not directly depends on the arguments of the constructor, but rather used as a refinement for data it operates on, so old implementation wasn't very helpful and new more flexible but a bit more complex factory should address that.